### PR TITLE
Patches to silence warnings and fix install target

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -55,9 +55,9 @@ install:  awka_exe libawka
 	if [ ! -d $(MANSRCDIR)/man5 ]; then mkdir -p $(MANSRCDIR)/man5; fi
 	cd awka; $(MAKE) install
 	cd lib; $(MAKE) install
-	cp  doc/awka.1  $(AWKAMAN)
-	cp  doc/awka-elm.5  $(MANSRCDIR)/man5
-	cp  doc/awka-elmref.5  $(MANSRCDIR)/man5
+	cp  docs/awka.1  $(AWKAMAN)
+	cp  docs/awka-elm.5  $(MANSRCDIR)/man5
+	cp  docs/awka-elmref.5  $(MANSRCDIR)/man5
 	chmod  0644  $(AWKAMAN)
 
 clean:

--- a/awka/fin.h
+++ b/awka/fin.h
@@ -52,5 +52,7 @@ unsigned PROTO ( fillbuff, (int, char *, unsigned) ) ;
 extern  FIN  *main_fin ;  /* for the main input stream */
 void   PROTO( open_main, (void) ) ;
 
+#if MSDOS
 void  PROTO(setmode, (int,int)) ;
+#endif
 #endif  /* FIN_H */

--- a/awka/scan.c
+++ b/awka/scan.c
@@ -37,6 +37,8 @@
 #include  "repl.h"
 #include  "code.h"
 
+#include <unistd.h>
+
 #ifndef          NO_FCNTL_H
 #include  <fcntl.h>
 #endif

--- a/lib/builtin.c
+++ b/lib/builtin.c
@@ -21,6 +21,7 @@
 #include <limits.h>
 #include <ctype.h>
 #include <errno.h>
+#include <unistd.h>
 
 #ifndef NO_TIME_H
 #  include <time.h>

--- a/lib/io.c
+++ b/lib/io.c
@@ -19,6 +19,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+#include <sys/types.h>
 
 #define _IO_C
 #define _IN_LIBRARY

--- a/regexp/dfa.c
+++ b/regexp/dfa.c
@@ -39,6 +39,9 @@ extern char *calloc(), *malloc(), *realloc();
 extern void free();
 #endif
 
+// Failing to pick this up on FreeBSD
+#include <string.h>
+
 #if defined(HAVE_STRING_H) || defined(STDC_HEADERS)
 #include <string.h>
 #undef index

--- a/regexp/regex.c
+++ b/regexp/regex.c
@@ -600,6 +600,8 @@ extract_number_and_incr (destination, source)
 /* It is useful to test things that ``must'' be true when debugging.  */
 # include <assert.h>
 
+#include "dfa.h"
+
 static int debug;
 
 # define DEBUG_STATEMENT(e) e
@@ -5781,7 +5783,7 @@ _re_gsub_fixslashes(char *pattern)
 awka_regexp *
 awka_regcomp (patt, gsub)
     char *patt;
-    char gsub;
+    int gsub;
 {
   awka_regexp *preg;
   reg_errcode_t ret;

--- a/regexp/regex.h
+++ b/regexp/regex.h
@@ -540,7 +540,7 @@ extern int re_exec _RE_ARGS ((const char *));
 /* POSIX compatibility.  */
 /* extern int regcomp _RE_ARGS ((awka_regexp *__preg, const char *__pattern,
                               int __cflags)); */
-extern awka_regexp * awka_regcomp _RE_ARGS ((char *__pattern, char gsub));
+extern awka_regexp * awka_regcomp _RE_ARGS ((char *__pattern, int gsub));
 
 extern int awka_regexec _RE_ARGS ((awka_regexp *__preg,
                               char *__string, size_t __nmatch,


### PR DESCRIPTION
Here are some changes to silence warnings and fix the install target, which is using a non-existent "doc" directory.

There are many more code quality issues to clean up, but this is a start.

All tests pass, so maybe this could be released as 0.7.6 to continue where sourceforge left off?